### PR TITLE
Set produce_fc2's base _displacement_dataset to be _phonon_displaceme…

### DIFF
--- a/phono3py/phonon3/__init__.py
+++ b/phono3py/phonon3/__init__.py
@@ -255,7 +255,7 @@ class Phono3py(object):
                     is_compact_fc=False,
                     use_alm=False):
         if displacement_dataset is None:
-            disp_dataset = self._displacement_dataset
+            disp_dataset = self._phonon_displacement_dataset
         else:
             disp_dataset = displacement_dataset
 


### PR DESCRIPTION
Changes the default displacement dataset in produce_fc2 to _phonon_displacement_dataset. This would allow a user to pull the _displacement_dataset and _phonon_displacement_dataset to get the force sets used to calculate the second and third order force constants.