### PR TITLE
Type error in __init__.py

### DIFF
--- a/phono3py/phonon3/__init__.py
+++ b/phono3py/phonon3/__init__.py
@@ -255,7 +255,7 @@ class Phono3py(object):
                     is_compact_fc=False,
                     use_alm=False):
         if displacement_dataset is None:
-            disp_dataset = self._displacement_dataset
+            disp_dataset = self._phonon_displacement_dataset
         else:
             disp_dataset = displacement_dataset
 


### PR DESCRIPTION
I stumbled upon this error while trying to produce force constants of 2nd order for GaN. It only shows up when using supercell matrices of different spacegroups for 2nd and 3rd order. 

I hope I'm not mistaken.

Best,
Marcel Hülsberg