### PR TITLE
Parameter is_diagonal not properly passed

### DIFF
--- a/phono3py/phonon3/__init__.py
+++ b/phono3py/phonon3/__init__.py
@@ -242,7 +242,7 @@ class Phono3py(object):
             phonon_displacement_directions = get_least_displacements(
                 self._phonon_supercell_symmetry,
                 is_plusminus=is_plusminus,
-                is_diagonal=False)
+                is_diagonal=is_diagonal)
             self._phonon_displacement_dataset = directions_to_displacement_dataset(
                 phonon_displacement_directions,
                 distance,


### PR DESCRIPTION
I assume this happened during a test and was forgotten to be changed back? Causes more phonon supercell displacements to be calculated than needed.

Best, Marcel Hülsberg