### PR TITLE
add pyproject.toml for build dependency management

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy"]


### PR DESCRIPTION
similar to https://github.com/atztogo/phonopy/pull/98

Should not be necessary in principle, since `phono3py` has `phonopy` as dependency. However, since `setup.py` imports `numpy`, this PR would make sure that problems can never arise.