### PR TITLE
rename (optional) mkl.py to setup_mkl.py to avoids namespace clash with numpy

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -73,9 +73,9 @@ MKL LAPACKE (with multithread BLAS)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Phono3py can be compiled with MKL for using LAPACKE.  If ``setup.py``
-finds the file named ``mkl.py``, the contents of ``mkl.py`` is read
+finds the file named ``setup_mkl.py``, the contents of ``setup_mkl.py`` is read
 and those are included in the compilation setting.  For example, the
-following setting prepared as ``mkl.py`` seems working on Ubuntu 16.04
+following setting prepared as ``setup_mkl.py`` seems working on Ubuntu 16.04
 system::
 
    intel_root = "/opt/intel/composer_xe_2015.7.235"

--- a/setup.py
+++ b/setup.py
@@ -67,16 +67,16 @@ use_mkl = False
 #   Phono3py complex values are handled based on those provided by Netlib
 #   lapacke. However MKL lapacke doesn't provide some macros and functions
 #   that provided Netlib. This macro defines those used in phono3py among them.
-if os.path.isfile("mkl.py"):
+if os.path.isfile("setup_mkl.py"):
     # This supposes that MKL multithread BLAS is used.
-    # This is invoked when mkl.py exists on the current directory.
+    # This is invoked when setup_mkl.py exists on the current directory.
 
     print("MKL LAPACKE is to be used.")
     print("Use of icc is assumed (CC='icc').")
 
-    from mkl import mkl_extra_link_args_lapacke, mkl_include_dirs_lapacke
+    from setup_mkl import mkl_extra_link_args_lapacke, mkl_include_dirs_lapacke
 
-    #### Examples of mkl.py ####
+    #### Examples of setup_mkl.py ####
     # For 2015
     # intel_root = "/opt/intel/composer_xe_2015.7.235"
     # mkl_root = "%s/mkl" % intel_root


### PR DESCRIPTION
I had some problems running `python setup.py ...` from the `phono3py` folder when using the `mkl.py` file to configure `mkl` because of namespace clashes in `numpy`. By using an unambiguous name like `setup_mkl.py` for the configuration file, this problem can be solved. I suggest to use this name in this PR.

For reference, this is the error message I get from `numpy` when `mkl.py` is present:
```
>>> import numpy
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/knoop/local/anaconda3/envs/py38/lib/python3.8/site-packages/numpy/__init__.py", line 236, in <module>
    __mkl_version__ = "{MajorVersion}.{UpdateVersion}".format(**mkl.get_version())
AttributeError: module 'mkl' has no attribute 'get_version'
```